### PR TITLE
Add cmd/ctrl+click to open new tab on file-widget

### DIFF
--- a/addon/components/file-browser-item/component.js
+++ b/addon/components/file-browser-item/component.js
@@ -40,7 +40,9 @@ export default Ember.Component.extend({
         return guid ? pathJoin(window.location.origin, guid) : undefined;
     }),
     click(e) {
-        if (e.shiftKey || e.metaKey) {
+        if((e.metaKey || e.ctrlKey) && e.target.nodeName == 'A') {
+            window.open(this.get('link'));
+        } else if (e.shiftKey || e.metaKey) {
             this.sendAction('selectMultiple', this.get('item'), e.metaKey);
         } else {
             this.sendAction('selectItem', this.get('item'));

--- a/addon/components/file-browser-item/template.hbs
+++ b/addon/components/file-browser-item/template.hbs
@@ -2,7 +2,7 @@
     {{#unless item.flash.message}}
         <div class="col-sm-{{nameColumnWidth}} file-row-col col-xs-12 file-browser-header">
             {{file-browser-icon item=item}}
-            <a {{action 'open'}} role="link">{{item.itemName}}</a>
+            <a {{action 'open' preventDefault='true'}} role="link">{{item.itemName}}</a>
         </div>
         {{#if (if-filter 'size-column' display)}}
             <div class="col-sm-1 file-row-col hidden-xs file-browser-header">


### PR DESCRIPTION
# Purpose

Make it possible to `ctrl+click` and `cmd+click` on file links to open a new tab.

# Changes

- Added conditional to the ember click function to determine if `ctrl` or `cmd` keys were clicked on a link.

- Added `preventDefault='true'` to the file links to prevent it from loading the file on the current and new tab on `cmd/ctrl+click`.
