### PR TITLE
Upgrade to ember-toastr 1.7.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
         "lodash": "~3.7.0",
         "jquery-mockjax": "2.1.1",
         "dropzone": "~4.3.0",
-        "toastr": "^2.1.2",
         "font-awesome": "~4.5.0",
         "typeahead.js": "^0.11.1",
         "jquery.tagsinput": "^1.3.6",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
         "lodash": "~3.7.0",
         "jquery-mockjax": "2.1.1",
         "dropzone": "~4.3.0",
-        "font-awesome": "~4.5.0",
         "typeahead.js": "^0.11.1",
         "jquery.tagsinput": "^1.3.6",
         "c3": "0.4.11",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "ember-page-title": "3.2.0",
     "ember-power-select": "^1.8.4",
     "ember-resolver": "4.1.0",
-    "ember-toastr": "1.5.0",
     "eslint": "^3.19.0",
     "git-branch-is": "0.1.0",
     "loader": "2.1.1",
@@ -99,12 +98,14 @@
     "ember-simple-auth": "^1.3.0",
     "ember-sinon": "0.7.0",
     "ember-sinon-qunit": "1.6.0",
+    "ember-toastr": "1.7.0",
     "ember-truth-helpers": "1.3.0",
     "js-cookie": "2.1.4",
     "js-md5": "0.4.2",
     "js-yaml": "3.8.4",
     "keen-tracking": "1.1.3",
-    "langs": "1.0.2"
+    "langs": "1.0.2",
+    "toastr": "^2.1.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3523,9 +3523,9 @@ ember-text-measurer@^0.3.3:
   dependencies:
     ember-cli-babel "^5.1.6"
 
-ember-toastr@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/ember-toastr/-/ember-toastr-1.5.0.tgz#a71b0a6f080c149e4ab149d6a84a677b641373a3"
+ember-toastr@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ember-toastr/-/ember-toastr-1.7.0.tgz#74097611fe38c596b7ed6db4a2d00d47122cc8c7"
   dependencies:
     ember-cli-babel "^5.0.0"
 
@@ -8352,6 +8352,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.0, to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+toastr@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/toastr/-/toastr-2.1.2.tgz#fd69066ae7578a5b3357725fc9c7c335e9b681df"
 
 tough-cookie@>=0.12.0, tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
## Ticket

# Purpose

Upgrade to ember-toastr 1.7.0 which uses toastr from NPM (no bower dependency)

Also removed font-awesome from bower.json because https://github.com/martndemus/ember-font-awesome/releases/tag/3.0.0

# Notes for Reviewers

## Routes Added/Updated


